### PR TITLE
Refactory: Cambio de nombre de dbContext a SysAcopioDbContext

### DIFF
--- a/SysAcopio/Controllers/SysAcopioDbContext.cs
+++ b/SysAcopio/Controllers/SysAcopioDbContext.cs
@@ -9,11 +9,11 @@ using System.Threading.Tasks;
 
 namespace SysAcopio.Controllers
 {
-    public class DbContext
+    public class SysAcopioDbContext
     {
         private readonly string connectionStringDeRL;
 
-        public DbContext()
+        public SysAcopioDbContext()
         {
             // Accede a la cadena de conexión desde el archivo de configuración
             connectionStringDeRL = ConfigurationManager.ConnectionStrings["ConnectionStringDeRL"].ConnectionString;


### PR DESCRIPTION
 * Cambia nombre de la clase responsable de la coneccion a base de datos ya que el nombre antiguo era utilizado como palabra reservada por el lenguaje